### PR TITLE
chore(ci): add informational Codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,10 @@ ignore:
   - src/third-party
 coverage:
   status:
-    patch: off
-    project: off
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        informational: true
 comment: off


### PR DESCRIPTION
Hi, Tom from Codecov here. I noticed that you were using Codecov but weren't actually getting any notifications on pull requests. I figured it would be useful to get some idea if code being changed is being tested, but also not blocking CI/merging. Let me know if this makes sense or if we can do something that would be helpful.